### PR TITLE
Fix on Stop method

### DIFF
--- a/async/queue.go
+++ b/async/queue.go
@@ -78,5 +78,8 @@ func (wq *workQueue) WaitDone() {
 
 // Stop stops the job queue and the workers.
 func (wq *workQueue) Stop() {
+	close(wq.stopChan)
+	wq.jobs.Wait()
+	wq.done.Wait()
 	close(wq.jobChan)
 }


### PR DESCRIPTION
This commit fixes the `panic: sync: negative WaitGroup counter` error on the Stop method. Before to close the `jobChan` channel we need to close the `stopChan` channel to stop all the running workers.