### PR TITLE
Optimize UnsortedKV Locking

### DIFF
--- a/data/unsortedkv.go
+++ b/data/unsortedkv.go
@@ -14,7 +14,7 @@ import (
 // UnsortedKV is a thread safe and unsorted key-value
 // storage with optional persistency on disk.
 type UnsortedKV struct {
-	sync.Mutex
+	sync.RWMutex
 	fileName string
 	m        map[string]string
 	policy   FlushPolicy
@@ -65,15 +65,15 @@ func NewMemUnsortedKV() (*UnsortedKV, error) {
 // MarshalJSON is used to serialize the UnsortedKV data structure to
 // JSON correctly.
 func (u *UnsortedKV) MarshalJSON() ([]byte, error) {
-	u.Lock()
-	defer u.Unlock()
+	u.RLock()
+	defer u.RUnlock()
 	return json.Marshal(u.m)
 }
 
 // Has return true if name exists in the store.
 func (u *UnsortedKV) Has(name string) bool {
-	u.Lock()
-	defer u.Unlock()
+	u.RLock()
+	defer u.RUnlock()
 	_, found := u.m[name]
 	return found
 }
@@ -81,8 +81,8 @@ func (u *UnsortedKV) Has(name string) bool {
 // Get return the value of the named object if present, or returns
 // found as false otherwise.
 func (u *UnsortedKV) Get(name string) (v string, found bool) {
-	u.Lock()
-	defer u.Unlock()
+	u.RLock()
+	defer u.RUnlock()
 	v, found = u.m[name]
 	return
 }
@@ -108,8 +108,8 @@ func (u *UnsortedKV) flushUnlocked() error {
 // Flush flushes the store to disk if the flush policy
 // is different than FlushNone
 func (u *UnsortedKV) Flush() error {
-	u.Lock()
-	defer u.Unlock()
+	u.RLock()
+	defer u.RUnlock()
 	if u.policy != FlushNone {
 		return u.flushUnlocked()
 	}
@@ -162,7 +162,7 @@ func (u *UnsortedKV) Each(cb func(k, v string) bool) {
 
 // Empty returns bool if the store is empty.
 func (u *UnsortedKV) Empty() bool {
-	u.Lock()
-	defer u.Unlock()
+	u.RLock()
+	defer u.RUnlock()
 	return len(u.m) == 0
 }


### PR DESCRIPTION
Previously UnsortedKV strictly used a `sync.Mutex` for all operations. There would only be at most 1 reader regardless of whether there are any active write operations. This would provide extremely poor performance in a concurrent environment, such as bettercap. This change enables using `sync.RWMutex` for proper read/write locking which should cause a dramatic increase in performance within concurrent environments.